### PR TITLE
Fix: Correct import path for prisma module in auth

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,6 @@
 import { Lucia } from "lucia";
 import { PrismaAdapter } from "@lucia-auth/adapter-prisma";
-import { prisma } from "./prisma.js";
+import { prisma } from "./prisma";
 import { cookies } from "next/headers";
 
 const adapter = new PrismaAdapter(prisma.session, prisma.user);


### PR DESCRIPTION
I changed the import in `lib/auth.ts` from `./prisma.js` to `./prisma`. This resolves a 'Module not found' error during the Next.js build process, as it now correctly points to `lib/prisma.ts`, allowing the Next.js bundler to handle TypeScript module resolution and compilation.