### PR TITLE
Fix: Correct 'Forgot Password' link destination

### DIFF
--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -273,7 +273,7 @@ export function LandingPage() {
                           required
                         />
                         <div className="text-right">
-                          <a href="/forgot-password-email-entry" className="text-xs text-blue-600 hover:underline">
+                          <a href="/forgot-password" className="text-xs text-blue-600 hover:underline">
                             Forgot Password?
                           </a>
                         </div>


### PR DESCRIPTION
The 'Forgot Password?' link on the sign-in form was pointing to an incorrect URL (`/forgot-password-email-entry`), resulting in a 404 error.

This commit updates the `href` attribute in `components/landing-page.tsx` to point to the correct route (`/forgot-password`), which is handled by `app/(auth)/forgot-password/page.tsx`.