### PR TITLE
Fix: Correct DATABASE_URL to use service name

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@ MYSQL_ROOT_PASSWORD=rootpassword
 MYSQL_DATABASE=artisthub
 MYSQL_USER=user
 MYSQL_PASSWORD=password
-DATABASE_URL=mysql://user:password@localhost:3307/artisthub
-SHADOW_DATABASE_URL=mysql://user:password@localhost:3307/artisthub_shadow
+DATABASE_URL=mysql://user:password@db:3306/artisthub
+SHADOW_DATABASE_URL=mysql://user:password@db:3306/artisthub_shadow
 # Email settings
 EMAIL_SERVER_HOST=mailpit
 EMAIL_SERVER_PORT=1025


### PR DESCRIPTION
The application was unable to connect to the database because the DATABASE_URL in the .env file was configured to use localhost:3307. Within the Docker container, 'localhost' refers to the container itself, not the database service.

This commit updates the DATABASE_URL and SHADOW_DATABASE_URL to use the correct Docker service name 'db' and its internal port '3306' (e.g., mysql://user:password@db:3306/artisthub). This allows the application container to correctly resolve and connect to the database container.